### PR TITLE
Fix deprecated <bold> tag in example popups

### DIFF
--- a/3-webatlas.js-markers/js/main.js
+++ b/3-webatlas.js-markers/js/main.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
     map.LayerControl.addOverlay(marker, 'marker');
 
     //Knytt en popup til markøren ved klikk.
-    marker.bindPopup("Her kan det være <bold>HTML</bold>");
+    marker.bindPopup("Her kan det være <b>HTML</b>");
 
     
 

--- a/4-webatlas.js-geojson/js/main.js
+++ b/4-webatlas.js-geojson/js/main.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
     map.LayerControl.addOverlay(marker, 'marker');
 
     //Knytt en popup til markøren ved klikk.
-    marker.bindPopup("Her kan det være <bold>HTML</bold>");
+    marker.bindPopup("Her kan det være <b>HTML</b>");
 
     
 

--- a/5-webatlas.js-circlemarker/js/main.js
+++ b/5-webatlas.js-circlemarker/js/main.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
     map.LayerControl.addOverlay(marker, 'marker');
 
     //Knytt en popup til markøren ved klikk.
-    marker.bindPopup("Her kan det være <bold>HTML</bold>");
+    marker.bindPopup("Her kan det være <b>HTML</b>");
 
     
 

--- a/6-webatlas.js-minimap/js/main.js
+++ b/6-webatlas.js-minimap/js/main.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
     map.LayerControl.addOverlay(marker, 'marker');
 
     //Knytt en popup til markøren ved klikk.
-    marker.bindPopup("Her kan det være <bold>HTML</bold>");
+    marker.bindPopup("Her kan det være <b>HTML</b>");
 
     
 

--- a/7-webatlas.js-viz/js/main.js
+++ b/7-webatlas.js-viz/js/main.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
     map.LayerControl.addOverlay(marker, 'marker');
 
     //Knytt en popup til markøren ved klikk.
-    marker.bindPopup("Her kan det være <bold>HTML</bold>");
+    marker.bindPopup("Her kan det være <b>HTML</b>");
 
     
 


### PR DESCRIPTION
Replace `<bold>` with `<b>`. 
Low hanging fruit :-)
